### PR TITLE
Bump Security String to 2021-06-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2021-05-05
+      PLATFORM_SECURITY_PATCH := 2021-06-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2021-0478   A-169255797  EoP    High       8.1, 9, 10, 11
CVE-2021-0506   A-181962311  EoP    High       8.1, 9, 10, 11
CVE-2021-0507   A-181860042  RCE    Critical   8.1, 9, 10, 11
CVE-2021-0508   A-176444154  EoP    High       8.1, 9, 10, 11
CVE-2021-0509   A-176444161  EoP    High       8.1, 9, 10, 11
CVE-2021-0510   A-176444622  EoP    High       8.1, 9, 10, 11
CVE-2021-0511   A-178055795  EoP    High       9, 10, 11
CVE-2021-0513   A-156090809  EoP    High       8.1, 9, 10, 11
CVE-2021-0516   A-181660448  EoP    Critical   8.1, 9, 10, 11
CVE-2021-0520   A-176237595  EoP    High       10, 11
CVE-2021-0521   A-174661955  ID     High       8.1, 9, 10, 11
CVE-2021-0522   A-174182139  ID     High       9, 10, 11
CVE-2021-0523   A-174047492  EoP    High       10, 11

Previously Implemented:
=======================
CVE:            References:  Type:  Severity:  Updated AOSP versions:  Prior Change:
CVE-2020-26555  A-174626251  EoP    High       8.1, 9, 10, 11          09ec6a0dc, fef3f3513
CVE-2020-26558  A-174886838  EoP    High       8.1, 9, 10, 11          76da71cbf, 9976bfe24

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2021-0504   A-179162665  ID     High       11
CVE-2021-0505   A-179975048  EoP    High       11
CVE-2021-0517   A-179053823  ID     High       11

Change-Id: I7a2a2678f8b9f384d9d73b1d3ca4ad45b77a30dd